### PR TITLE
Change id type of User domain and add organisation and related embedded classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Nucleus Plugin (Latest 1.0.0)
+# Nucleus Plugin (Latest 1.1.0)
 
 Nucleus > 1.0.0 supports Grails 3.3.x
 Nucleus < 0.5.5 supports Grails 3.2.x (Tested upto 3.2.5)
@@ -23,32 +23,32 @@ Use command: `grails test-app`
 ### Domains
 
 - **User**, **Role**, **UserRole**:
-A default domain generated using spring security core plugin to use standard user lookup, Customized according to 
+A default domain generated using spring security core plugin to use standard user lookup, Customized according to
 `CauseCode` application requirement.
-- **Country** : 
+- **Country** :
 Used for storing country name and code.
-- **PhoneCountryCode** : 
+- **PhoneCountryCode** :
 Used for storing country code with `Country`.
-- **Phone** : 
+- **Phone** :
 Used for storing phone number with `PhoneCountryCode`.
-- **City** : 
+- **City** :
 Used for storing city related information with `Country`.
-- **Location** : 
+- **Location** :
 Used for storing location related information with `City`.
-- **Currency** : 
+- **Currency** :
 Used for storing currency code and name.
-- **Contact** : 
+- **Contact** :
 A generic domain used to store `User` social network contact ID's, `Location` and `Phone`.
-- **Url** : 
+- **Url** :
 Used in conjunction with Sitemap.
-- **Sitemap** : 
+- **Sitemap** :
 Used for tracking request URL for which search engine discover these application.
 
 ### Controllers/Trait
 
-- **Currency** : 
+- **Currency** :
 Provides default CRUD end point for Admin.
-- **Sitemap** : 
+- **Sitemap** :
 Provides end point to `generate` sitemap.
 - **RestfulController** :
 This controller extends the Grails default RestfulController and overrides the index and delete actions.
@@ -58,16 +58,16 @@ that are required by all the controllers in the App.
 
 ### Utility Classes
 
-- **SitemapMarshaller** : 
+- **SitemapMarshaller** :
 Used to render sitemap in sitemap.xml pattern.
-- **CustomValidationErrorMarshaller** : 
+- **CustomValidationErrorMarshaller** :
 Used to render generic customizable validation error messages for domains.
-- **CustomUserDetailsService** : 
+- **CustomUserDetailsService** :
 Provides methods `loadUserByUsername` accepts String argument as username and returns user by username or email.
 **Note**: If User not found throws `UsernameNotFoundException` exception.
-- **DateUtil** : 
+- **DateUtil** :
 Provides multiple methods which transforms Dates.
-- **NucleusTagLib** : 
+- **NucleusTagLib** :
     - Provides `pagerInfo` tagLib with parameters max, offset and total.
     - Used to render HTML elements showing response for list pages record status.
 
@@ -77,7 +77,7 @@ Provides multiple methods which transforms Dates.
 
 1. A module named **angular** is required in order to user user management screen.
 
-### TagLib pagerInfo 
+### TagLib pagerInfo
 Generic tagLib used to render pagination information for list pages.
 
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
 }
 
 group "com.causecode.plugins"
-version "1.1.0-RC1"
+version "1.1.0"
 
 apply plugin: 'idea'
 apply plugin: 'org.grails.grails-plugin'

--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,9 @@ dependencies {
 
     compile "org.grails.plugins:asynchronous-mail:2.0.2"
 
+    // https://mvnrepository.com/artifact/org.mongodb/bson
+    compile 'org.mongodb:bson:2.3'
+
     console "org.grails:grails-console"
 
     profile "org.grails.profiles:web-plugin"

--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,8 @@ dependencies {
 
     runtime "com.h2database:h2"
 
+    compile 'com.causecode.plugins:mongo-update-embedded:2.0.0'
+
     testCompile "org.grails:grails-test-mixins:3.3.0"
     testCompile "org.grails:grails-gorm-testing-support"
     testCompile "org.grails:grails-web-testing-support"

--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ dependencies {
 
     runtime "com.h2database:h2"
 
-    compile 'com.causecode.plugins:mongo-update-embedded:2.0.0'
+    compile 'com.causecode.plugins:mongo-update-embedded:2.0.1'
 
     testCompile "org.grails:grails-test-mixins:3.3.0"
     testCompile "org.grails:grails-gorm-testing-support"

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
 }
 
 group "com.causecode.plugins"
-version "1.0.0"
+version "1.1.0-RC1"
 
 apply plugin: 'idea'
 apply plugin: 'org.grails.grails-plugin'

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,12 @@
 # ChangeLog
 
+## Version 1.1.0 - [Unreleased]
+### Changed
+- User domain to support ObjectId and embedded classes support.
+
 ## Version 1.0.0 - [Unreleased]
 ### Changed
-- Upgraded the plugin to support grails 3.3.5 
+- Upgraded the plugin to support grails 3.3.5
 
 ## Version 0.5.5 - [09-04-2018]
 
@@ -39,7 +43,7 @@
 * ####CircleCI configuration
     -  `.circleci/config.yml` for build automation using `CircleCI`.
     - `mavenCredsSetup.sh` for generating `gradle.properties` during the CircleCI build.
-    
+
 ## v0.5.1 - [01-11-2017]
 
 ### Fixed

--- a/grails-app/domain/com/causecode/organization/Organization.groovy
+++ b/grails-app/domain/com/causecode/organization/Organization.groovy
@@ -1,0 +1,38 @@
+package com.causecode.organization
+
+import com.causecode.organization.embedded.EmOrganization
+import groovy.transform.EqualsAndHashCode
+import groovy.transform.ToString
+import org.bson.types.ObjectId
+
+/**
+ * This domain represent an organization.
+ *
+ * @author Siddharth Shishulkar
+ * @since 0.0.9
+ */
+@EqualsAndHashCode
+@ToString(includes = ['id', 'name'], includePackage = false)
+@SuppressWarnings('GrailsDomainReservedSqlKeywordName') // Not using SQL database. So reserved keyword won't matter.
+class Organization {
+    ObjectId id
+
+    String name    // Name of the organization.
+    String domain  // Domain of the organization.
+
+    Date dateCreated
+    Date lastUpdated
+
+    static constraints = {
+        dateCreated bindable: false
+        lastUpdated bindable: false
+    }
+
+    /**
+     * This getter returns an embedded instance of {link Organization}.
+     * @return {@link com.causecode.organization.embedded.EmOrganization}
+     */
+    EmOrganization getEmbeddedInstance() {
+        return new EmOrganization(name: name, domain: domain, instanceId: id)
+    }
+}

--- a/grails-app/domain/com/causecode/organization/Organization.groovy
+++ b/grails-app/domain/com/causecode/organization/Organization.groovy
@@ -7,9 +7,6 @@ import org.bson.types.ObjectId
 
 /**
  * This domain represent an organization.
- *
- * @author Siddharth Shishulkar
- * @since 0.0.9
  */
 @EqualsAndHashCode
 @ToString(includes = ['id', 'name'], includePackage = false)

--- a/grails-app/domain/com/causecode/user/User.groovy
+++ b/grails-app/domain/com/causecode/user/User.groovy
@@ -56,6 +56,10 @@ class User {
     }
 
     static mapping = {
+        /*
+         * In Grails 3.3.5 Domain class autowiring is disabled by default due to its impact on performance so enabling
+         * it for this domain class only.
+         */
         autowire true
         password column: '`password`'
     }

--- a/grails-app/domain/com/causecode/user/User.groovy
+++ b/grails-app/domain/com/causecode/user/User.groovy
@@ -1,9 +1,12 @@
 package com.causecode.user
 
+import com.causecode.organization.embedded.EmOrganization
+import com.causecode.user.embedded.EmUser
 import grails.databinding.BindingFormat
 import grails.plugin.springsecurity.SpringSecurityService
 import groovy.transform.EqualsAndHashCode
 import groovy.transform.ToString
+import org.bson.types.ObjectId
 
 /**
  * User groovy class used to specify person entity with default information.
@@ -13,6 +16,7 @@ import groovy.transform.ToString
 @SuppressWarnings(['GrailsDomainWithServiceReference'])
 class User {
 
+    ObjectId id
     SpringSecurityService springSecurityService
     boolean accountExpired
     boolean accountLocked
@@ -33,7 +37,11 @@ class User {
     String username
     String pictureURL
 
+    EmOrganization organization
+
     static transients = ['springSecurityService']
+
+    static embedded = ['organization']
 
     static constraints = {
         email blank: false, email: true, unique: true
@@ -44,15 +52,10 @@ class User {
         firstName maxSize: 100, nullable: true
         lastName maxSize: 100, nullable: true
         pictureURL nullable: true
-        dateCreated bindable: false
-        lastUpdated bindable: false
+        organization nullable: true
     }
 
     static mapping = {
-        /*
-         * In Grails 3.3.5 Domain class autowiring is disabled by default due to its impact on performance so enabling
-         * it for this domain class only.
-         */
         autowire true
         password column: '`password`'
     }
@@ -78,6 +81,15 @@ class User {
     }
 
     String getFullName() {
-       return firstName + ' ' + lastName
+        return firstName + ' ' + lastName
+    }
+
+    /**
+     * Method to get embedded instance of User
+     */
+    EmUser getEmbeddedInstance() {
+        return new EmUser([instanceId: this.id, accountExpired: this.accountExpired, accountLocked: this.accountLocked,
+                           enabled: this.enabled, email: this.email, firstName: this.firstName, lastName: this.lastName,
+                           username: this.username])
     }
 }

--- a/grails-app/domain/com/causecode/user/UserRole.groovy
+++ b/grails-app/domain/com/causecode/user/UserRole.groovy
@@ -2,6 +2,7 @@ package com.causecode.user
 
 import groovy.transform.ToString
 import org.apache.commons.lang.builder.HashCodeBuilder
+import org.bson.types.ObjectId
 
 /**
  * UserRole join groovy class specifies authority for user.
@@ -40,6 +41,12 @@ class UserRole implements Serializable {
         }
 
         builder.toHashCode()
+    }
+
+    static UserRole get(ObjectId userId, long roleId) {
+        UserRole.where {
+            user == User.load(userId) && role == Role.load(roleId)
+        }.get()
     }
 
     static UserRole get(long userId, long roleId) {

--- a/src/main/groovy/com/causecode/organization/embedded/EmOrganization.groovy
+++ b/src/main/groovy/com/causecode/organization/embedded/EmOrganization.groovy
@@ -1,0 +1,14 @@
+package com.causecode.organization.embedded
+
+import com.causecode.mongo.embeddable.EmbeddableDomain
+import org.bson.types.ObjectId
+
+/**
+ * Embedded class for the Organization domain.
+ */
+class EmOrganization implements EmbeddableDomain {
+    ObjectId instanceId
+
+    String name
+    String domain
+}

--- a/src/main/groovy/com/causecode/user/embedded/EmUser.groovy
+++ b/src/main/groovy/com/causecode/user/embedded/EmUser.groovy
@@ -1,0 +1,53 @@
+package com.causecode.user.embedded
+
+import com.causecode.mongo.embeddable.EmbeddableDomain
+import org.bson.types.ObjectId
+
+/**
+ * This class represents embedded instance of User domain.
+ */
+class EmUser implements EmbeddableDomain {
+
+    ObjectId instanceId
+    boolean accountExpired
+    boolean accountLocked
+    boolean enabled = true
+
+    String email
+    String firstName
+    String lastName
+    String username
+
+    EmUser() {
+    }
+
+    static constraints = {
+        email blank: false, email: true
+        firstName maxSize: 100, nullable: true
+        lastName maxSize: 100, nullable: true
+    }
+
+    EmUser(Map params) {
+        this.instanceId = params.instanceId
+        this.accountExpired = params.accountExpired
+        this.accountLocked = params.accountLocked
+        this.enabled = params.enabled
+        this.email = params.email
+        this.firstName = params.firstName
+        this.lastName = params.lastName
+        this.username = params.username
+    }
+
+    Map<String, String> getFieldsAsMap() {
+        return [
+                'instanceId': this.instanceId,
+                'accountExpired': this.accountExpired,
+                'accountLocked': this.accountLocked,
+                'enabled': this.enabled,
+                'email': this.email,
+                'firstName': this.firstName,
+                'lastName': this.lastName,
+                'username': this.username
+        ]
+    }
+}


### PR DESCRIPTION
Fixed the User domain and published the plugin successfully. 
Also needed to add ObjectId to the User domain and the following classes and domain because they were present in the app's User domain
-- EmUser
-- Organization/EmOrganization - A property present in the User domain used in Tag feature so required to move this domain in the plugin to build.